### PR TITLE
Cloning link updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 
 ```bash
 # 1. یک کپی از مخزن کد بگیرید
-git clone git@github.com:reactjs/fa.reactjs.org.git
+git clone https://github.com/reactjs/fa.reactjs.org.git
 
 # 2. به شاخه اصلی پروژه بروید
 cd fa.reactjs.org


### PR DESCRIPTION
The previous link was trying to connect with "git" username and that gives me access denied. Regular cloning link ( without git username ) replaced.

screenshot of the error: 
![clone premission denied](https://cdn1.imggmi.com/uploads/2019/2/24/744bb8031c3bf2ddceb50f856fd043ba-full.png)
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
